### PR TITLE
Add node affinity to k8s

### DIFF
--- a/ansible-dojot/roles/ejbca-node/templates/ejbca_cluster.yaml.j2
+++ b/ansible-dojot/roles/ejbca-node/templates/ejbca_cluster.yaml.j2
@@ -5,6 +5,15 @@ metadata:
   name: ejbca-simple
   namespace: {{ dojot_namespace }}
 spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/hostname
+            operator: NotIn
+            values:
+            - verne-kafka
   selector:
     matchLabels:
       app: ejbca-simple

--- a/ansible-dojot/roles/kafka/templates/kafka_statefulset.yaml.j2
+++ b/ansible-dojot/roles/kafka/templates/kafka_statefulset.yaml.j2
@@ -13,6 +13,14 @@ spec:
         name: kafka-server
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - verne-kafka
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/ansible-dojot/roles/vernemq-webhook/templates/webhook_cluster.yaml.j2
+++ b/ansible-dojot/roles/vernemq-webhook/templates/webhook_cluster.yaml.j2
@@ -14,6 +14,15 @@ spec:
       labels:
         app: webhook-verne
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - verne-kafka
       containers:
       - name: webhook-verne
         image: jonaphael/vernemq-webhook

--- a/ansible-dojot/roles/vernemq/templates/z_vernemq_cluster.yaml.j2
+++ b/ansible-dojot/roles/vernemq/templates/z_vernemq_cluster.yaml.j2
@@ -7,6 +7,15 @@ metadata:
   namespace: {{ dojot_namespace }}
 spec:
   baseImage: mprevide/verne
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/hostname
+            operator: NotIn
+            values:
+            - verne-kafka
   env:
     - name: STATIC_CERT
       value: "n"

--- a/ansible-dojot/roles/zookeeper/templates/zk_statefulset.yaml.j2
+++ b/ansible-dojot/roles/zookeeper/templates/zk_statefulset.yaml.j2
@@ -29,6 +29,14 @@ spec:
         runAsUser: 1000
         fsGroup: 1000
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - verne-kafka
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
            - topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
It separates Kafka and Zookeeper from VerneMQ, Webhooks and EJBCA. The other
services remain unchanged.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)


* **Other information**:
