### PR TITLE
Add --export option in generate_certs script

### DIFF
--- a/locust/src/scripts/generate_certs.py
+++ b/locust/src/scripts/generate_certs.py
@@ -311,6 +311,12 @@ if __name__ == "__main__":
         action="store_true",
         default=False
     )
+    MEGROUP.add_argument(
+        "--export",
+        help="exports the certificates",
+        action="store_true",
+        default=False
+    )
     ARGS = PARSER.parse_args()
 
     logging.basicConfig(**CONFIG["app"]["log_config"])
@@ -348,3 +354,9 @@ if __name__ == "__main__":
 
     if ARGS.cleardb:
         clear_db()
+
+    if ARGS.export:
+        # Exports the certificates' files
+        export_certs()
+        # Retrieving the CA certificate
+        retrieve_ca_cert()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
There is no option to export the certificates from Redis. They are only exported after the generation.


* **What is the new behavior (if this is a feature change)?**
Adds a --export option to allow the exportation of the certificates.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)


* **Other information**:
